### PR TITLE
jaeger opentracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.5.RELEASE</version>
+        <version>1.4.4.RELEASE</version>
     </parent>
 
     <groupId>de.zalando</groupId>
@@ -43,6 +43,37 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>4.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-web-autoconfigure</artifactId>
+            <version>0.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.uber.jaeger</groupId>
+            <artifactId>jaeger-core</artifactId>
+            <version>0.20.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>0.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter</groupId>
+            <artifactId>zipkin-sender-okhttp3</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.instana</groupId>
+            <artifactId>instana-java-opentracing</artifactId>
+            <version>0.20.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jdbc</artifactId>
+            <version>0.0.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/de/zalando/zmon/eventlogservice/EventlogController.java
+++ b/src/main/java/de/zalando/zmon/eventlogservice/EventlogController.java
@@ -1,9 +1,12 @@
 package de.zalando.zmon.eventlogservice;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.opentracing.util.GlobalTracer;
+import com.uber.jaeger.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.bind.annotation.*;
@@ -48,6 +51,18 @@ public class EventlogController {
 
             storage.putEvent(e);
         }
+    }
+
+    @Bean
+    public io.opentracing.Tracer jaegerTracer() {
+
+        com.uber.jaeger.Configuration config = com.uber.jaeger.Configuration.fromEnv();
+
+        io.opentracing.Tracer tracer = config.getTracer();
+
+        GlobalTracer.register(tracer);
+
+        return tracer;
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/de/zalando/zmon/eventlogservice/PostgresqlStore.java
+++ b/src/main/java/de/zalando/zmon/eventlogservice/PostgresqlStore.java
@@ -31,7 +31,7 @@ public class PostgresqlStore implements EventStore {
 
     public PostgresqlStore(String host, int port, String database, String user, String password, String schema) {
         HikariConfig conf = new HikariConfig();
-        conf.setJdbcUrl("jdbc:postgresql://" + host + ":" + port + "/" + database);
+        conf.setJdbcUrl("jdbc:tracing:postgresql://" + host + ":" + port + "/" + database);
         conf.setUsername(user);
         conf.setPassword(password);
         conf.setMaximumPoolSize(12);


### PR DESCRIPTION
Opentracing java instrumentation using jaeger tracer where the configuration is loaded through environment variables.
          JAEGER_SERVICE_NAME: "zmon-notification-service"
          JAEGER_AGENT_HOST: "jaeger"
          JAEGER_AGENT_PORT: 5775
          JAEGER_REPORTER_LOG_SPANS: "true"
          JAEGER_REPORTER_MAX_QUEUE_SIZE: 100
          JAEGER_TAGS: "opentracing=poc"
          JAEGER_REPORTER_FLUSH_INTERVAL: 100
          JAEGER_SAMPLER_TYPE: "probabilistic"
          JAEGER_SAMPLER_PARAM: 1